### PR TITLE
feat: use mimalloc as global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +305,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -387,6 +415,7 @@ dependencies = [
  "compact_str",
  "criterion",
  "hashbrown",
+ "mimalloc",
  "pyo3",
  "serde",
  "serde_json",
@@ -565,6 +594,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 compact_str = { version = "0.8.1", features = ["serde"] }
 hashbrown = "0.15.2"
+mimalloc = "0.1.43"
 pyo3 = "0.23.3"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,14 @@ use std::{
 };
 
 use hashbrown::HashMap;
+use mimalloc::MiMalloc;
 use pyo3::{exceptions::PyIOError, prelude::*, types::PyList};
 use serde::{Deserialize, Serialize};
 
 use crate::compact_string::CompactString;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 const LE: CompactString = CompactString::const_new("le");
 const PID: CompactString = CompactString::const_new("pid");


### PR DESCRIPTION
This gets us some non-negligible speedups, presumably because we have
to clone and allocate so many strings during aggregation. Benchmark
over the `compact-str` branch:

```
❯ cargo bench
    ...
     Running benches/my_benchmark.rs (target/release/deps/my_benchmark-d1231a6dbf807c0c)
merge_internal          time:   [67.516 µs 67.615 µs 67.725 µs]
                        change: [-11.009% -10.801% -10.611%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
```
